### PR TITLE
Fix Facebook scopes for cross-posting

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -18,7 +18,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
   if AppConfig.services.facebook.enable?
     provider :facebook, AppConfig.services.facebook.app_id, AppConfig.services.facebook.secret, {
       display: 'popup',
-      scope: 'publish_actions,publish_stream,offline_access',
+      scope: 'public_profile,publish_actions',
       client_options: {
         ssl: {
           ca_file: AppConfig.environment.certificate_authorities


### PR DESCRIPTION
Facebook deprecated their v1.0 API and thus the old ones no longer work (for new authorizations).
